### PR TITLE
Allow configuration from environment variables

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,8 @@ In the **Authorized redirect URIs** add the SSO endpoint for your installation::
 
     https://sentry.example.com/auth/sso/
 
-Finally, obtain the API keys and plug them into your ``sentry.conf.py``:
+Finally, obtain the API keys and configure the ``GOOGLE_CLIENT_ID`` and ``GOOGLE_CLIENT_SECRET`` as environment variables.
+Alternatively, you can plug them into your ``sentry.conf.py``:
 
 .. code-block:: python
 

--- a/sentry_auth_google/constants.py
+++ b/sentry_auth_google/constants.py
@@ -2,14 +2,16 @@ from __future__ import absolute_import, print_function
 
 from django.conf import settings
 
+import os
+env = os.environ.get
 
 AUTHORIZE_URL = 'https://accounts.google.com/o/oauth2/auth'
 
 ACCESS_TOKEN_URL = 'https://www.googleapis.com/oauth2/v4/token'
 
-CLIENT_ID = getattr(settings, 'GOOGLE_CLIENT_ID', None)
+CLIENT_ID = env('GOOGLE_CLIENT_ID') or getattr(settings, 'GOOGLE_CLIENT_ID', None)
 
-CLIENT_SECRET = getattr(settings, 'GOOGLE_CLIENT_SECRET', None)
+CLIENT_SECRET = env('GOOGLE_CLIENT_SECRET') or getattr(settings, 'GOOGLE_CLIENT_SECRET', None)
 
 ERR_INVALID_DOMAIN = 'The domain for your Google account (%s) is not allowed to authenticate with this provider.'
 


### PR DESCRIPTION
Allows configuration of the GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET using Environment Variables

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry-auth-google/10)

<!-- Reviewable:end -->
