### PR TITLE
Force the padded string to be string

### DIFF
--- a/sentry_auth_google/utils.py
+++ b/sentry_auth_google/utils.py
@@ -5,4 +5,4 @@ import base64
 
 def urlsafe_b64decode(b64string):
     padded = b64string + b'=' * (4 - len(b64string) % 4)
-    return base64.urlsafe_b64decode(padded)
+    return base64.urlsafe_b64decode(str(padded))


### PR DESCRIPTION
The padded string was an unicode string which is not allowed in the base64.urlsafe_b64decode function.

See https://stackoverflow.com/questions/20849805/python-hmac-typeerror-character-mapping-must-return-integer-none-or-unicode/20862445 for reference.

Fixes #31 